### PR TITLE
fix: Maven detection fails for Bazel 5

### DIFF
--- a/unused_deps_py/BUILD.bazel
+++ b/unused_deps_py/BUILD.bazel
@@ -49,7 +49,7 @@ py_wheel(
     license = "Apache 2.0",
     python_tag = "py3",
     python_requires = '>=3',
-    version = "0.0.4",
+    version = "0.0.5",
     deps = [
       ":unused_deps_py_pkg",
     ],

--- a/unused_deps_py/main.py
+++ b/unused_deps_py/main.py
@@ -47,7 +47,7 @@ Note these may be used at run time; see documentation for more information.
     parser.add_argument(
         '--version',
         action='version',
-        version='%(prog)s 0.0.4'
+        version='%(prog)s 0.0.5'
     )
 
     parser.add_argument(

--- a/unused_deps_py/unused_deps_py_lib/processor.py
+++ b/unused_deps_py/unused_deps_py_lib/processor.py
@@ -182,7 +182,7 @@ class Processor:
 
     def get_maven_repos(self) -> List[str]:
         fetch = "coursier_fetch"
-        repos = self.execute_bazel_command('query', '--output=xml', f'"kind({fetch}, //external:all)"')
+        repos = self.execute_bazel_command('query', '--output=xml', f'"kind({fetch}, //external:*)"')
         parsed = ElementTree.fromstring(repos)
         out = list()
         for rule in parsed.iter('rule'):


### PR DESCRIPTION
Since Bazel 5, the target "//external:all" doesn't work anymore, while "//external:*" still works. With this change, unused Maven dependencies are detected again.