### PR TITLE
Bump `rules_python` to fix RECORD in `.whl` file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.5.0/rules_python-0.5.0.tar.gz",
-    sha256 = "cd6730ed53a002c56ce4e2f396ba3b3be262fd7cb68339f0377a45e8227fe332",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.11.0.tar.gz",
+    sha256 = "c03246c11efd49266e8e41e12931090b613e12a59e6f55ba2efd29a7cb8b4258",
+    strip_prefix = "rules_python-0.11.0",
 )
 
 http_archive(

--- a/unused_deps_py/BUILD.bazel
+++ b/unused_deps_py/BUILD.bazel
@@ -49,7 +49,7 @@ py_wheel(
     license = "Apache 2.0",
     python_tag = "py3",
     python_requires = '>=3',
-    version = "0.0.5",
+    version = "0.0.6",
     deps = [
       ":unused_deps_py_pkg",
     ],

--- a/unused_deps_py/main.py
+++ b/unused_deps_py/main.py
@@ -47,7 +47,7 @@ Note these may be used at run time; see documentation for more information.
     parser.add_argument(
         '--version',
         action='version',
-        version='%(prog)s 0.0.5'
+        version='%(prog)s 0.0.6'
     )
 
     parser.add_argument(


### PR DESCRIPTION
Prior to `rules_python` version 0.11.0, `py_wheel` used to generate invalid RECORD entries for file paths outside of the current package:
```python
Traceback (most recent call last):
  File "[...]/pip_install/extract_wheels/extract_single_wheel.py", line 105, in <module>
    main()
  File "[...]/pip_install/extract_wheels/extract_single_wheel.py", line 93, in main
    bazel.extract_wheel(
  File "[...]/pip_install/extract_wheels/bazel.py", line 364, in extract_wheel
    whl.unzip(directory)
  File "[...]/pip_install/extract_wheels/wheel.py", line 90, in unzip
    installer.install(
  File "[...]/pypi__installer/installer/_core.py", line 96, in install
    for record_elements, stream, is_executable in source.get_contents():
  File "[...]/pypi__installer/installer/sources.py", line 158, in get_contents
    assert record is not None, "In {}, {} is not mentioned in RECORD".format(
AssertionError: In unused_deps_py-0.0.5-py3-none-any.whl, compatibility_tests/v2.5.0/tests/__init__.py is not mentioned in RECORD
```

This was reported through https://github.com/bazelbuild/rules_python/issues/745, then fixed by https://github.com/bazelbuild/rules_python/pull/789.

`rules_python`'s version gets here conservatively bumped to the corresponding bugfix version: [0.11.0](https://github.com/bazelbuild/rules_python/releases/tag/0.11.0)

Practically, the main difference between `unused_deps_py-0.0.5.dist-info/RECORD` and `unused_deps_py-0.0.6.dist-info/RECORD` consists in leading `/` being stripped:
```diff
-/compatibility_tests/v2.5.0/tests/__init__.py,sha256=8SXBh8YGxPXGDmFtR_n90wt5xWvc5CEp_L5Pn687VaU,150
[...]
-/compatibility_tests/v2.5.0/tests/google/protobuf/internal/__init__.py,sha256=H-9Le6XWW7Ikwaq9qPneZts4ZitfM2XgeK4x-B5joTA,1867
+compatibility_tests/v2.5.0/tests/__init__.py,sha256=8SXBh8YGxPXGDmFtR_n90wt5xWvc5CEp_L5Pn687VaU,150
[...]
+compatibility_tests/v2.5.0/tests/google/protobuf/internal/__init__.py,sha256=H-9Le6XWW7Ikwaq9qPneZts4ZitfM2XgeK4x-B5joTA,1867
```
and:
```diff
-/google/__init__.py,sha256=8SXBh8YGxPXGDmFtR_n90wt5xWvc5CEp_L5Pn687VaU,150
[...]
-/google/protobuf/wrappers_pb2.py,sha256=xybMLGFD_xtm-GZ0owcWN-44dDkI5oR2U8Tl_ZngwpQ,12473
+google/__init__.py,sha256=8SXBh8YGxPXGDmFtR_n90wt5xWvc5CEp_L5Pn687VaU,150
[...]
+google/protobuf/wrappers_pb2.py,sha256=xybMLGFD_xtm-GZ0owcWN-44dDkI5oR2U8Tl_ZngwpQ,12473
```

Note: with latest version of `rules_python` (0.14.0 as of Nov 24, 2022), the build would fail on:
> ERROR: [...]/unused_deps_py/unused_deps_py_lib/BUILD.bazel:5:11: no such package '@unused_deps_py_pip_java_manifest//': The repository '@unused_deps_py_pip_java_manifest' could not be resolved: Repository '@unused_deps_py_pip_java_manifest' is not defined and referenced by '//unused_deps_py/unused_deps_py_lib:unused_deps_py_lib'

Cc @ngeor @manuelnaranjo