### PR TITLE
Make `Processor.get_used_deps` yield only explicit dependencies

### DIFF
--- a/unused_deps_py/unused_deps_py_lib/processor.py
+++ b/unused_deps_py/unused_deps_py_lib/processor.py
@@ -232,4 +232,5 @@ class Processor:
         dependencies = deps_pb2.Dependencies()
         dependencies.ParseFromString(body)
         for dependency in dependencies.dependency:
-            yield dependency.path
+            if dependency.kind == deps_pb2.Dependency.Kind.EXPLICIT:
+                yield dependency.path


### PR DESCRIPTION
It turns out that dependencies deserialized from `jdeps` files don't necessarily denote explicitly used dependencies. Their [Kind](https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/deps.proto#L32) may indeed be one of:
1. `EXPLICIT`:
   > Dependency used explicitly in the source.
2. `IMPLICIT`:
   > Dependency that is implicitly loaded and used by the compiler.
3. `UNUSED`:
   > Unused dependency.
4. `INCOMPLETE`:
   > Implicit dependency considered by the compiler but not completed.

Without considering their kind, implicit dependencies (eg. brought to the compile classpath through a transitive dependency) get treated as explicitly used and therefore not proposed for removal by `unused_deps_py`.

The present change therefore consists in filtering out non-explicit dependencies.